### PR TITLE
Rewrite setup.py to be similar to the other services

### DIFF
--- a/sequencing_report_service/__init__.py
+++ b/sequencing_report_service/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Johan Dahlberg"""
 __email__ = 'johan.dahlberg@medsci.uu.se'
-__version__ = '0.1.0'
+__version__ = '1.3.1'

--- a/setup.py
+++ b/setup.py
@@ -1,53 +1,27 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-"""The setup script."""
-
 from setuptools import setup, find_packages
+from sequencing_report_service import __version__
+import os
 
-with open('README.md') as readme_file:
-    readme = readme_file.read()
+def read_file(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-with open('version.txt') as version_file:
-    # We use the format vx.x.x in out tags
-    # but this format is not a valid python
-    # wheel version, so we remove it here.
-    version = version_file.read().split('v')[1]
-
-requirements = ['arteria', 'sqlalchemy', 'alembic']
-
-setup_requirements = ['pytest-runner', ]
-
-test_requirements = ['pytest', ]
+try:
+    with open("requirements/prod", "r") as f:
+        install_requires = [x.strip() for x in f.readlines()]
+except IOError:
+    install_requires = []
 
 setup(
-    author="Johan Dahlberg",
-    author_email='johan.dahlberg@medsci.uu.se',
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-    ],
-    description="Service producing and displaying sequencing reports.",
-    install_requires=requirements,
-    license="MIT license",
-    long_description=readme,
-    include_package_data=True,
-    keywords='sequencing_report_service',
     name='sequencing_report_service',
+    version=__version__,
+    description="Service producing and displaying sequencing reports.",
+    long_description=read_file('README.md'),
+    keywords='bioinformatics',
+    author='SNP&SEQ Technology Platform, Uppsala University',
     packages=find_packages(include=["sequencing_report_service*"]),
-    setup_requires=setup_requirements,
-    test_suite='tests',
-    tests_require=test_requirements,
-    url='https://gitlab.snpseq.medsci.uu.se/shared/sequencing-report-service/sequencing_report_service',
-    version=version,
-    zip_safe=False,
+    include_package_data=True,
     entry_points={
         'console_scripts': ['sequencing-report-service = sequencing_report_service.app:start']
     },
-
+    install_requires=install_requires,
 )


### PR DESCRIPTION
The former setup script was relying on the CI/CD to update `version.txt`. Since this service is moved to miarka, this feature won't be in place anymore.

This PR harmonizes `setup.py` so that it is similar to the same file in the other arteria services.