### PR TITLE
Interpolate environment variables

### DIFF
--- a/sequencing_report_service/nextflow.py
+++ b/sequencing_report_service/nextflow.py
@@ -58,7 +58,9 @@ class NextflowCommandGenerator():
         defaults = {'runfolder_path': str(runfolder_path),
                     'runfolder_name': runfolder_path.name,
                     'current_year': datetime.datetime.now().year}
-        conf = configparser.ConfigParser(defaults=defaults, interpolation=configparser.ExtendedInterpolation())
+        conf = configparser.ConfigParser(
+                defaults=defaults,
+                interpolation=configparser.ExtendedInterpolation())
         params_as_conf_dict = {'nextflow_config': self._raw_params}
         conf.read_dict(params_as_conf_dict)
 
@@ -71,6 +73,25 @@ class NextflowCommandGenerator():
 
         return lst
 
+    def _construct_environment(self, runfolder_path):
+        """
+        Interpolates default values in the environment config
+        """
+        defaults = {'runfolder_path': str(runfolder_path),
+                    'runfolder_name': runfolder_path.name,
+                    'current_year': datetime.datetime.now().year}
+        conf = configparser.ConfigParser(
+                defaults=defaults,
+                interpolation=configparser.ExtendedInterpolation())
+        conf.optionxform = str
+        env_as_conf_dict = {'environment': self._config_dict.get('environment')}
+        conf.read_dict(env_as_conf_dict)
+
+        return {
+            key: conf['environment'][key]
+            for key in env_as_conf_dict['environment']
+        }
+
     def command(self, runfolder):
         """
         Return a list containing the command to run with the specified runfolder
@@ -80,7 +101,7 @@ class NextflowCommandGenerator():
         if not isinstance(runfolder, Path):
             runfolder = Path(runfolder)
         cmd = self._cmd + self._construct_nf_param_list(runfolder)
-        env_config = self._config_dict.get('environment')
+        env_config = self._construct_environment(runfolder)
         nf_command = {'command': cmd, 'environment': env_config}
         log.debug("Generated command: %s", nf_command)
         return nf_command

--- a/tests/test_nextflow.py
+++ b/tests/test_nextflow.py
@@ -11,7 +11,10 @@ def test_command():
               'nf_profile': 'singularity,snpseq',
               'environment':
               {
-                  'NXF_TEMP': '/tmp_foo'
+                  'NXF_TEMP': '/tmp_foo',
+                  'TEST_RUNFOLDER': '${DEFAULT:runfolder_name}',
+                  'TEST_PATH': '${DEFAULT:runfolder_path}',
+                  'TEST_YEAR': '${DEFAULT:current_year}',
               },
               'parameters':
                   {'hello': '${DEFAULT:runfolder_path}',
@@ -30,7 +33,12 @@ def test_command():
         '--name', 'runfolder',
     ]
 
-    assert result['environment'] == {'NXF_TEMP': '/tmp_foo'}
+    assert result['environment'] == {
+        'NXF_TEMP': '/tmp_foo',
+        'TEST_RUNFOLDER': 'runfolder',
+        'TEST_PATH': '/path/to/runfolder',
+        'TEST_YEAR': str(datetime.datetime.now().year),
+    }
 
 
 def test_raises_on_no_parameters_section():


### PR DESCRIPTION
In order to set the Nextflow work directory we need to be able to interpolate environment variables the way we do with Nextflow parameters.

This PR fixes that and updates the tests accordingly.