### PR TITLE
Improve error handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import asyncio
+import pytest_asyncio
+
+
+# This is somehow necessary to make it possible to run all the async tests.
+# From: https://stackoverflow.com/questions/66054356/multiple-async-unit-tests-fail-but-running-them-one-by-one-will-pass
+
+
+@pytest_asyncio.fixture(scope="session")
+def event_loop(request):
+    """Create an instance of the default event loop for the whole session."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()


### PR DESCRIPTION
This PR makes sure the state of a job is updated properly when a job is interrupted. More specifically:
* When the job returns a non-zero status, `wait_for_exit()` will raise an exception. When catching this exception, the job status is updated to `ERROR`.
* When cancelling a job, it's status is first set to `CANCELLED` and then the job is killed. This prevents a race condition where the job status would first be set to `CANCELLED` and the to `ERROR`.

Tests have been updated, although testing async code with pytest was a bit shaky and required additional configuration.