### PR TITLE
Implement command generator for arbitrary pipelines

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Run Unit Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,27 +7,33 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install wheel
-        pip install -r requirements/dev .
-    - name: Install Nextflow
-      uses: nf-core/setup-nextflow@v1
-      with:
-        version: "22.10.6"
-    - name: Install apptainer
-      run: |
-        sudo add-apt-repository -y ppa:apptainer/ppa
-        sudo apt update
-        sudo apt install -y apptainer
-    - name: Launch tests
-      run: |
-        pytest ./tests
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          pip install -r requirements/dev .
+          npm install -g pajv
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: "22.10.6"
+      - name: Install apptainer
+        run: |
+          sudo add-apt-repository -y ppa:apptainer/ppa
+          sudo apt update
+          sudo apt install -y apptainer
+      - name: Launch tests
+        run: |
+          pytest ./tests
+      - name: Validate pipeline config files
+        run: >
+          pajv
+          -s config/pipeline_config/schema.json
+          -d config/pipeline_config/*.yml

--- a/config/app.config
+++ b/config/app.config
@@ -9,25 +9,4 @@ alembic_log_config_path: config/logger.config
 alembic_scripts: ./alembic/
 reports_dir: ./tests/resources/reports/
 nextflow_log_dirs: /path/to/nextflow_log_dirs
-
-nextflow_config:
-    main_workflow_path: ./seqreports/main.nf
-    nf_config: ./seqreports/config/nextflow.config
-    nf_profile: singularity,snpseq
-    environment:
-        NXF_TEMP: /tmp/
-        NXF_WORK: /tmp/nf_work/
-        NXF_ANSI_LOG: false
-    # Note that in the parameters section it is possible to do variable
-    # subsitution on the following variables.
-    # loading the config.
-    # - ${DEFAULT:runfolder_name}
-    # - ${DEFAULT:runfolder_path}
-    # - ${DEFAULT:current_year}
-    parameters:
-        run_folder: ${DEFAULT:runfolder_path}
-        config_dir: ./seqreports/config/
-        fastqscreen_databases: /opt/FastQ_Screen_Genomes/
-        checkqc_config: /etc/checkqc/config.yaml
-        result_dir: ${DEFAULT:runfolder_path}/reports
-        script_dir: ./seqreports/bin/
+pipeline_config_dir: ./config/pipeline_config/

--- a/config/pipeline_config/schema.json
+++ b/config/pipeline_config/schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "required": [
+    "main_workflow_path",
+    "nf_config",
+    "nf_profile",
+    "environment",
+    "parameters"
+  ],
+  "properties": {
+    "main_workflow_path": {"type": "string"},
+    "nf_config": {"type": "string"},
+    "nf_profile": {"type": "string"},
+    "environment": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    }
+  },
+  "additionalProperties": false
+}

--- a/config/pipeline_config/schema.json
+++ b/config/pipeline_config/schema.json
@@ -16,7 +16,8 @@
     "nextflow_parameters": {
       "type": "object",
       "additionalProperties": {"type": "string"}
-    }
+    },
+    "input_samplesheet": { "type": "string" }
   },
   "additionalProperties": false
 }

--- a/config/pipeline_config/schema.json
+++ b/config/pipeline_config/schema.json
@@ -1,19 +1,19 @@
 {
   "type": "object",
   "required": [
-    "main_workflow_path",
-    "nf_config",
-    "nf_profile"
+    "main_workflow_path"
   ],
   "properties": {
     "main_workflow_path": {"type": "string"},
-    "nf_config": {"type": "string"},
-    "nf_profile": {"type": "string"},
     "environment": {
       "type": "object",
       "additionalProperties": {"type": "string"}
     },
-    "parameters": {
+    "pipeline_parameters": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "nextflow_parameters": {
       "type": "object",
       "additionalProperties": {"type": "string"}
     }

--- a/config/pipeline_config/schema.json
+++ b/config/pipeline_config/schema.json
@@ -3,9 +3,7 @@
   "required": [
     "main_workflow_path",
     "nf_config",
-    "nf_profile",
-    "environment",
-    "parameters"
+    "nf_profile"
   ],
   "properties": {
     "main_workflow_path": {"type": "string"},

--- a/config/pipeline_config/seqreports.yml
+++ b/config/pipeline_config/seqreports.yml
@@ -6,7 +6,7 @@ main_workflow_path: ./seqreports/main.nf
 # - {runfolder_name}
 # - {runfolder_path}
 # - {current_year}
-# - {input_samplesheet}
+# - {input_samplesheet_path}
 environment:
   NXF_TEMP: /tmp/
   NXF_WORK: /tmp/nf_work/

--- a/config/pipeline_config/seqreports.yml
+++ b/config/pipeline_config/seqreports.yml
@@ -6,6 +6,7 @@ main_workflow_path: ./seqreports/main.nf
 # - {runfolder_name}
 # - {runfolder_path}
 # - {current_year}
+# - {input_samplesheet}
 environment:
   NXF_TEMP: /tmp/
   NXF_WORK: /tmp/nf_work/

--- a/config/pipeline_config/seqreports.yml
+++ b/config/pipeline_config/seqreports.yml
@@ -1,10 +1,8 @@
 ---
 
 main_workflow_path: ./seqreports/main.nf
-nf_config: ./seqreports/config/nextflow.config
-nf_profile: singularity,snpseq
-# Note that in the parameters and environment sections it is possible to do
-# variable subsitution on the following variables:
+# Note that in the following sections it is possible to do variable subsitution
+# on the following variables:
 # - {runfolder_name}
 # - {runfolder_path}
 # - {current_year}
@@ -12,10 +10,13 @@ environment:
   NXF_TEMP: /tmp/
   NXF_WORK: /tmp/nf_work/
   NXF_ANSI_LOG: "false"
-parameters:
+pipeline_parameters:
   run_folder: "{runfolder_path}"
   config_dir: ./seqreports/config/
   fastqscreen_databases: /opt/FastQ_Screen_Genomes/
   checkqc_config: /etc/checkqc/config.yaml
   result_dir: "{runfolder_path}/reports"
   script_dir: ./seqreports/bin/
+nextflow_parameters:
+  config: ./seqreports/config/nextflow.config
+  profile: singularity,snpseq

--- a/config/pipeline_config/seqreports.yml
+++ b/config/pipeline_config/seqreports.yml
@@ -1,0 +1,21 @@
+---
+
+main_workflow_path: ./seqreports/main.nf
+nf_config: ./seqreports/config/nextflow.config
+nf_profile: singularity,snpseq
+# Note that in the parameters and environment sections it is possible to do
+# variable subsitution on the following variables:
+# - {runfolder_name}
+# - {runfolder_path}
+# - {current_year}
+environment:
+  NXF_TEMP: /tmp/
+  NXF_WORK: /tmp/nf_work/
+  NXF_ANSI_LOG: "false"
+parameters:
+  run_folder: "{runfolder_path}"
+  config_dir: ./seqreports/config/
+  fastqscreen_databases: /opt/FastQ_Screen_Genomes/
+  checkqc_config: /etc/checkqc/config.yaml
+  result_dir: "{runfolder_path}/reports"
+  script_dir: ./seqreports/bin/

--- a/requirements/prod
+++ b/requirements/prod
@@ -3,3 +3,4 @@ wheel==0.37.1
 arteria==1.1.4
 sqlalchemy==1.4.41
 alembic==1.8.1
+jsonschema==4.19

--- a/sequencing_report_service/app.py
+++ b/sequencing_report_service/app.py
@@ -111,7 +111,8 @@ def configure_routes(config):
     session_factory = scoped_session(sessionmaker())
     session_factory.configure(bind=engine)
 
-    nextflow_command_generator = NextflowCommandGenerator(config['nextflow_config'])
+    nextflow_command_generator = NextflowCommandGenerator(
+        config['pipeline_config_dir'])
 
     job_repo_factory = functools.partial(JobRepository, session_factory=session_factory)
     local_runner_service = LocalRunnerService(job_repo_factory,

--- a/sequencing_report_service/app.py
+++ b/sequencing_report_service/app.py
@@ -26,7 +26,6 @@ from sequencing_report_service.repositiories.job_repo import JobRepository
 from sequencing_report_service.repositiories.reports_repo import ReportsRepository
 from sequencing_report_service.repositiories.runfolder_repo import RunfolderRepository
 from sequencing_report_service.exceptions import ConfigurationError
-from sequencing_report_service.nextflow import NextflowCommandGenerator
 
 log = logging.getLogger(__name__)
 
@@ -111,13 +110,12 @@ def configure_routes(config):
     session_factory = scoped_session(sessionmaker())
     session_factory.configure(bind=engine)
 
-    nextflow_command_generator = NextflowCommandGenerator(
-        config['pipeline_config_dir'])
-
     job_repo_factory = functools.partial(JobRepository, session_factory=session_factory)
-    local_runner_service = LocalRunnerService(job_repo_factory,
-                                              nextflow_command_generator,
-                                              config['nextflow_log_dirs'])
+    local_runner_service = LocalRunnerService(
+        job_repo_factory,
+        config['pipeline_config_dir'],
+        config['nextflow_log_dirs'],
+    )
 
     monitored_dirs = get_key_from_config(config, 'monitored_directories')
     runfolder_repo = RunfolderRepository(monitored_dirs)

--- a/sequencing_report_service/app.py
+++ b/sequencing_report_service/app.py
@@ -40,7 +40,7 @@ def routes(**kwargs):
     """
     return [
         url(r"/api/1.0/version", VersionHandler, name="version", kwargs=kwargs),
-        url(r"/api/1.0/jobs/start/(?!.*\/)(.*)$", JobStartHandler, name="job_start", kwargs=kwargs),
+        url(r"/api/1.0/jobs/start/(\w+)/(?!.*\/)(.*)$", JobStartHandler, name="job_start", kwargs=kwargs),
         url(r"/api/1.0/jobs/stop/(\d+)$", JobStopHandler, name="job_stop", kwargs=kwargs),
         url(r"/api/1.0/jobs/(\d+)$", OneJobHandler, name="one_job", kwargs=kwargs),
         url(r"/api/1.0/jobs/$", ManyJobHandler, name="many_jobs", kwargs=kwargs),

--- a/sequencing_report_service/handlers/job_handler.py
+++ b/sequencing_report_service/handlers/job_handler.py
@@ -115,7 +115,7 @@ class JobStartHandler(BaseRestHandler):
             {"link": "http://localhost:9999/api/1.0/jobs/130"}
 
         This endpoint also support the following parameters:
-            - `input_samplesheet`: content of the nf-core input samplesheet to
+            - `input_samplesheet_content`: content of the nf-core input samplesheet to
             input to the pipeline
             - `ext_args`: extra arguments to pass to the pipeline
         """
@@ -126,7 +126,7 @@ class JobStartHandler(BaseRestHandler):
             job_id = self.runner_service.start(
                     pipeline,
                     runfolder_path=runfolder_path,
-                    input_samplesheet=request_data.get("input_samplesheet", ""),
+                    input_samplesheet_content=request_data.get("input_samplesheet_content", ""),
                     ext_args=request_data.get("ext_args", "").split(" "),
                     )
             self.set_status(status_code=ACCEPTED)

--- a/sequencing_report_service/nextflow.py
+++ b/sequencing_report_service/nextflow.py
@@ -164,7 +164,11 @@ class NextflowCommandGenerator():
         cmd += [
             arg
             for key, value in config.get("pipeline_parameters", {}).items()
-            for arg in [f"--{key}", f"{value}"]
+            for arg in (
+                [f"--{key}", f"{value}"]
+                if value else
+                [f"--{key}"]
+            )
         ]
 
         log.debug("Generated command: %s", cmd)

--- a/sequencing_report_service/nextflow.py
+++ b/sequencing_report_service/nextflow.py
@@ -35,7 +35,11 @@ def interpolate_variables(config, defaults):
     """
     config = copy.deepcopy(config)
     try:
-        for section in ["environment", "parameters"]:
+        for section in [
+                    "environment",
+                    "pipeline_parameters",
+                    "nextflow_parameters",
+                ]:
             for key, value in config[section].items():
                 config[section][key] = value.format(**defaults)
     except KeyError:
@@ -98,14 +102,22 @@ class NextflowCommandGenerator():
 
         cmd = [
             'nextflow',
-            '-config', config['nf_config'],
             'run', config['main_workflow_path'],
-            '-profile', config['nf_profile'],
         ]
 
         cmd += [
             arg
-            for key, value in config["parameters"].items()
+            for key, value in config["nextflow_parameters"].items()
+            for arg in (
+                [f"-{key}", f"{value}"]
+                if value else
+                [f"-{key}"]
+            )
+        ]
+
+        cmd += [
+            arg
+            for key, value in config["pipeline_parameters"].items()
             for arg in [f"--{key}", f"{value}"]
         ]
 

--- a/sequencing_report_service/nextflow.py
+++ b/sequencing_report_service/nextflow.py
@@ -10,9 +10,156 @@ import json
 import jsonschema
 import yaml
 
-from sequencing_report_service.exceptions import NextflowConfigError
-
 log = logging.getLogger(__name__)
+
+
+def nextflow_command(
+    pipeline,
+    runfolder_path,
+    config_dir,
+    input_samplesheet_content="",
+    ext_args=None,
+):
+    """
+    Generate a Nextflow command according to parameters specified in
+    a configuration file. The file should be named after the pipeline eg.
+    `pipeline_name.yml`.
+
+    The following variables in the config file as well as in the input
+    samplesheet will be interpolated with the parameters passed in to this
+    function:
+    - {runfolder_name}
+    - {runfolder_path}
+    - {current_year}
+    - {input_samplesheet_path}
+
+    Parameters
+    ----------
+    pipeline: str
+        pipeline to use, there must be a corresponding {pipeline}.yml file in
+        the config directory
+    runfolder_path: str
+        path to runfolder to process
+    config_dir: str
+        path to directory containing the pipeline config files
+    input_samplesheet_content: str
+        content of the pipeline's input samplesheet
+    ext_args: [str]
+        list of extra arguments to append to the command. These will override
+        the arguments defined in the config file
+
+    Returns
+    -------
+        command_with_env: dict
+    """
+    raw_config = get_config(config_dir, pipeline)
+    input_samplesheet_content = (
+        input_samplesheet_content
+        or raw_config.get("input_samplesheet_content", "")
+    )
+    defaults = build_defaults(
+        pipeline,
+        runfolder_path,
+        input_samplesheet_content
+    )
+    config = interpolate_variables(raw_config, defaults)
+
+    env = config.get("environment", {})
+    cmd = [
+        'nextflow',
+        'run', config['main_workflow_path'],
+    ]
+
+    cmd += [
+        arg
+        for key, value in config.get("nextflow_parameters", {}).items()
+        for arg in ([f"-{key}", f"{value}"] if value else [f"-{key}"])
+    ]
+
+    cmd += [
+        arg
+        for key, value in config.get("pipeline_parameters", {}).items()
+        for arg in ([f"--{key}", f"{value}"] if value else [f"--{key}"])
+    ]
+
+    if ext_args:
+        cmd += ext_args
+
+    log.debug("Generated command: %s", cmd)
+
+    return {"command": cmd, "environment": env}
+
+
+def get_config(config_dir, pipeline):
+    """
+    Load and validate the config file for the requested pipeline.
+
+    Parameters
+    ----------
+    config_dir: str
+        path to directory containing the config files
+    pipeline: str
+        pipeline to load
+
+    Returns
+    -------
+        config: dict
+    """
+    config_dir = Path(config_dir)
+    try:
+        with open(config_dir / f"{pipeline}.yml", "r") as config_file:
+            config = yaml.safe_load(config_file.read())
+        with open(config_dir / "schema.json", "r") as pipeline_config_schema:
+            schema = json.load(pipeline_config_schema)
+        jsonschema.validate(config, schema)
+    except (FileNotFoundError, jsonschema.ValidationError):
+        log.exception('')
+        raise
+
+    return config
+
+
+def build_defaults(pipeline, runfolder_path, input_samplesheet_content):
+    """
+    Fetch default values to be used with `interpolate_variables`.
+
+    This will also write down the content of the input samplesheet to a file
+    in the runfolder and set its path as one of the default fields.
+
+    Parameters
+    ----------
+    pipeline: str
+        pipeline to use
+    runfolder_path: str
+        path to the runfolder to process
+    input_samplesheet_content: str
+        content of the input samplesheet that will be given to the nextflow
+        pipeline.
+
+    Returns
+    -------
+    defaults: dict
+    """
+    runfolder_path = Path(runfolder_path)
+    defaults = {
+        "current_year": datetime.datetime.now().year,
+        "runfolder_path": str(runfolder_path),
+        "runfolder_name": runfolder_path.name,
+    }
+
+    if input_samplesheet_content:
+        try:
+            input_samplesheet_content = input_samplesheet_content.format(**defaults)
+        except KeyError:
+            log.exception('')
+            raise
+
+        input_samplesheet_path = runfolder_path / f"{pipeline}_samplesheet.csv"
+        with open(input_samplesheet_path, "w") as f:
+            f.write(input_samplesheet_content)
+        defaults["input_samplesheet_path"] = str(input_samplesheet_path)
+
+    return defaults
 
 
 def interpolate_variables(config, defaults):
@@ -30,7 +177,7 @@ def interpolate_variables(config, defaults):
 
     Returns
     -------
-    dict
+    config: dict
         dictionaries with interpolated variables
     """
     config = copy.deepcopy(config)
@@ -50,130 +197,3 @@ def interpolate_variables(config, defaults):
         raise
 
     return config
-
-
-class NextflowCommandGenerator():
-    """
-    A class to generate Nextflow commands according to parameters specified in
-    a configuration file. The file should be named after the pipeline eg.
-    `pipeline_name.yml`.
-
-    Attributes
-    -----------
-    config_dir: str
-        path were the pipeline config files are located
-    """
-    def __init__(self, config_dir):
-        self.config_dir = Path(config_dir)
-
-    def _get_config(
-        self,
-        pipeline,
-        runfolder_path,
-        input_samplesheet,
-    ):
-        """
-        Fetches the config data for the given pipeline.
-
-        This will also format keywords `{current_year}`, `{runfolder_name}`,
-        `{runfolder_path}` and `{input_samplesheet}`.
-
-        Parameters
-        ----------
-        pipeline: str
-            name of the pipeline to use
-        runfolder_path: str
-            path to the runfolder to process
-        input_samplesheet: str
-            content of the input samplesheet
-
-        Returns
-        -------
-        config: dict
-       """
-        try:
-            with open(self.config_dir / f"{pipeline}.yml", "r") as config_file:
-                config = yaml.safe_load(config_file.read())
-            with open(self.config_dir / "schema.json", "r") as pipeline_config_schema:
-                schema = json.load(pipeline_config_schema)
-            jsonschema.validate(config, schema)
-        except (FileNotFoundError, jsonschema.ValidationError):
-            log.exception('')
-            raise
-
-        runfolder_path = Path(runfolder_path)
-        defaults = {
-            "current_year": datetime.datetime.now().year,
-            "runfolder_path": str(runfolder_path),
-            "runfolder_name": runfolder_path.name,
-        }
-
-        input_samplesheet = input_samplesheet or config.get("input_samplesheet", "")
-        if input_samplesheet:
-            try:
-                input_samplesheet = input_samplesheet.format(**defaults)
-            except KeyError:
-                log.exception('')
-                raise
-
-            input_samplesheet_path = runfolder_path / f"{pipeline}_samplesheet.csv"
-            with open(input_samplesheet_path, "w") as f:
-                f.write(input_samplesheet)
-            defaults["input_samplesheet"] = input_samplesheet_path
-
-        return interpolate_variables(config, defaults)
-
-    def command(
-        self,
-        pipeline,
-        runfolder_path,
-        input_samplesheet="",
-    ):
-        """
-        Returns nextflow command to run the requested pipeline
-        with parameter as specified in the corresponding config file.
-
-        Parameters
-        ----------
-        pipeline: str
-            name of the pipeline to use
-        runfolder_path: str
-            path to the runfolder to process
-        input_samplesheet: str
-            content of the input samplesheet
-        """
-        config = self._get_config(pipeline, runfolder_path, input_samplesheet)
-
-        env_config = config.get("environment", {})
-
-        cmd = [
-            'nextflow',
-            'run', config['main_workflow_path'],
-        ]
-
-        cmd += [
-            arg
-            for key, value in config.get("nextflow_parameters", {}).items()
-            for arg in (
-                [f"-{key}", f"{value}"]
-                if value else
-                [f"-{key}"]
-            )
-        ]
-
-        cmd += [
-            arg
-            for key, value in config.get("pipeline_parameters", {}).items()
-            for arg in (
-                [f"--{key}", f"{value}"]
-                if value else
-                [f"--{key}"]
-            )
-        ]
-
-        log.debug("Generated command: %s", cmd)
-
-        return {
-            'command': cmd,
-            'environment': env_config,
-        }

--- a/sequencing_report_service/repositiories/reports_repo.py
+++ b/sequencing_report_service/repositiories/reports_repo.py
@@ -66,7 +66,9 @@ class ReportsRepository:
     def _find_runfolder_dir(self, runfolder):
         result = self._bf_search(runfolder, self._reports_dir, 3)
         if not result:
-            raise RunfolderNotFound
+            raise RunfolderNotFound(
+                f"Could not identify a runfolder with the name: "
+                f"{runfolder} in any of the monitored directories.")
         return result
 
     def get_report_with_version(self, runfolder, version):

--- a/sequencing_report_service/services/local_runner_service.py
+++ b/sequencing_report_service/services/local_runner_service.py
@@ -102,14 +102,30 @@ class LocalRunnerService:
                     cmd_log=cmd_log,
                 )
 
-    def start(self, runfolder):
+    def start(
+        self,
+        pipeline,
+        runfolder_path,
+        input_samplesheet="",
+        ext_args=None,
+    ):
         """
         Start a new job for the specified runfolder
-        :param runfolder:
+        :param pipeline: name of the pipeline to run
+        :param runfolder_path: path to the runfolder to process
+        :param ext_args: extra args to append to the nextflow command
         :return: the job id of the started job
         """
         with self._job_repo_factory() as job_repo:
-            nf_cmd = self._nextflow_jobs_factory.command(runfolder)
+            nf_cmd = self._nextflow_jobs_factory.command(
+                pipeline,
+                runfolder_path,
+                input_samplesheet=input_samplesheet,
+            )
+
+            if ext_args:
+                nf_cmd['command'] += ext_args
+
             job_id = job_repo.add_job(command_with_env=nf_cmd).job_id
         log.debug("calling start_process with id %s" % str(job_id))
         loop = asyncio.get_running_loop()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,10 +56,12 @@ class TestIntegration(AsyncHTTPTestCase):
 
         pipeline_config = {
             'main_workflow_path': str(src_path / 'seqreports/main.nf'),
-            'nf_config': str(src_path / 'seqreports/nextflow.config'),
-            'nf_profile': 'singularity,snpseq,test',
             'environment': {'NXF_TEMP': '/tmp/'},
-            'parameters': {
+            'nextflow_parameters': {
+                'config': str(src_path / 'seqreports/nextflow.config'),
+                'profile': 'singularity,snpseq,test',
+            },
+            'pipeline_parameters': {
                 # This is only a placeholder because the service won't
                 # accept an empty parameter list
                 'hello': '{runfolder_path}',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -79,7 +79,7 @@ class TestIntegration(AsyncHTTPTestCase):
                 'main_workflow_path': "socks",
                 'environment': {'NXF_TEMP': '/tmp/'},
                 "pipeline_parameters": {
-                    "input": "{input_samplesheet}",
+                    "input": "{input_samplesheet_path}",
                 },
             },
         }
@@ -206,7 +206,7 @@ class TestIntegration(AsyncHTTPTestCase):
 
     def test_start_job_with_input_samplesheet(self):
         body = {
-            "input_samplesheet": "test,test",
+            "input_samplesheet_content": "test,test",
         }
         response = self.fetch(
             self.get_url('/api/1.0/jobs/start/socks_samplesheet/foo_runfolder'),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,17 +54,33 @@ class TestIntegration(AsyncHTTPTestCase):
             'pipeline_config_dir': f'{self.config_dir}/pipeline_config/',
         }
 
-        pipeline_config = {
-            'main_workflow_path': str(src_path / 'seqreports/main.nf'),
-            'environment': {'NXF_TEMP': '/tmp/'},
-            'nextflow_parameters': {
-                'config': str(src_path / 'seqreports/nextflow.config'),
-                'profile': 'singularity,snpseq,test',
+        pipeline_configs = {
+            "seqreports": {
+                'main_workflow_path': str(src_path / 'seqreports/main.nf'),
+                'environment': {'NXF_TEMP': '/tmp/'},
+                'nextflow_parameters': {
+                    'config': str(src_path / 'seqreports/nextflow.config'),
+                    'profile': 'singularity,snpseq,test',
+                },
+                'pipeline_parameters': {
+                    # This is only a placeholder because the service won't
+                    # accept an empty parameter list
+                    'hello': '{runfolder_path}',
+                },
             },
-            'pipeline_parameters': {
-                # This is only a placeholder because the service won't
-                # accept an empty parameter list
-                'hello': '{runfolder_path}',
+            "socks": {
+                'main_workflow_path': "socks",
+                'environment': {'NXF_TEMP': '/tmp/'},
+                "pipeline_parameters": {
+                    "style": "ascii",
+                },
+            },
+            "socks_samplesheet": {
+                'main_workflow_path': "socks",
+                'environment': {'NXF_TEMP': '/tmp/'},
+                "pipeline_parameters": {
+                    "input": "{input_samplesheet}",
+                },
             },
         }
 
@@ -72,11 +88,13 @@ class TestIntegration(AsyncHTTPTestCase):
             app_config_file.write(yaml.dump(app_config))
 
         Path(app_config["pipeline_config_dir"]).mkdir(exist_ok=True)
-        with open(
-                    Path(self.config_dir) / "pipeline_config" / "seqreports.yml",
-                    'w'
-                ) as pipeline_config_file:
-            pipeline_config_file.write(yaml.dump(pipeline_config))
+
+        for name, config in pipeline_configs.items():
+            with open(
+                        Path(self.config_dir) / "pipeline_config" / f"{name}.yml",
+                        'w'
+                    ) as pipeline_config_file:
+                pipeline_config_file.write(yaml.dump(config))
 
         shutil.copyfile(
             src_path / "config" / "pipeline_config" / "schema.json",
@@ -101,7 +119,7 @@ class TestIntegration(AsyncHTTPTestCase):
     @gen_test(timeout=120)
     def test_start_job(self):
         response = yield self.http_client.fetch(
-            self.get_url('/api/1.0/jobs/start/foo_runfolder'),
+            self.get_url('/api/1.0/jobs/start/seqreports/foo_runfolder'),
             method='POST', body=json.dumps({}))
         self.assertEqual(response.code, 202)
         status_link = json.loads(response.body).get('link', None)
@@ -129,7 +147,7 @@ class TestIntegration(AsyncHTTPTestCase):
         status_links = []
         for _ in range(2):
             response = self.fetch(
-                '/api/1.0/jobs/start/foo_runfolder',
+                '/api/1.0/jobs/start/seqreports/foo_runfolder',
                 method='POST', body=json.dumps({}))
             self.assertEqual(response.code, 202)
             status_link = json.loads(response.body).get('link', None)
@@ -150,9 +168,83 @@ class TestIntegration(AsyncHTTPTestCase):
                 f'/api/1.0/jobs/stop/{job_id}',
                 method='POST', body=json.dumps({}))
 
+    def test_start_job_missing_pipeline(self):
+        response = self.fetch(
+            self.get_url('/api/1.0/jobs/start/fake_pipeline/foo_runfolder'),
+            method='POST', body=json.dumps({}))
+        self.assertEqual(response.code, 404)
+
+    def test_start_job_with_extra_args(self):
+        body = {
+            "ext_args": "--style emoji",
+        }
+        response = self.fetch(
+            self.get_url('/api/1.0/jobs/start/socks/foo_runfolder'),
+            method='POST', body=json.dumps(body))
+        self.assertEqual(response.code, 202)
+        status_link = json.loads(response.body).get('link', None)
+        self.assertTrue(status_link)
+        status_response = self.fetch(status_link)
+        self.assertEqual(status_response.code, 200)
+        status_response_body = json.loads(status_response.body)
+        self.assertTrue(status_response_body.get('job_id'))
+        self.assertTrue(status_response_body.get('state'))
+
+        while status_response_body["state"] in [
+                State.NONE.value,
+                State.PENDING.value,
+                State.READY.value,
+                State.STARTED.value,
+                ]:
+            status_response = self.fetch(status_link)
+            self.assertEqual(status_response.code, 200)
+            status_response_body = json.loads(status_response.body)
+            time.sleep(1)
+
+        self.assertEqual(status_response_body["state"], State.DONE.value)
+        self.assertTrue("🧦" in status_response_body["log"])
+
+    def test_start_job_with_input_samplesheet(self):
+        body = {
+            "input_samplesheet": "test,test",
+        }
+        response = self.fetch(
+            self.get_url('/api/1.0/jobs/start/socks_samplesheet/foo_runfolder'),
+            method='POST', body=json.dumps(body))
+        self.assertEqual(response.code, 202)
+        status_link = json.loads(response.body).get('link', None)
+        self.assertTrue(status_link)
+        status_response = self.fetch(status_link)
+        self.assertEqual(status_response.code, 200)
+        status_response_body = json.loads(status_response.body)
+        self.assertTrue(status_response_body.get('job_id'))
+        self.assertTrue(status_response_body.get('state'))
+
+        while status_response_body["state"] in [
+                State.NONE.value,
+                State.PENDING.value,
+                State.READY.value,
+                State.STARTED.value,
+                ]:
+            status_response = self.fetch(status_link)
+            self.assertEqual(status_response.code, 200)
+            status_response_body = json.loads(status_response.body)
+            time.sleep(1)
+
+        src_path = (Path(__file__) / '..' / '..').resolve()
+        os.remove(src_path / "tests/resources/foo_runfolder/socks_samplesheet_samplesheet.csv")
+
+        self.assertEqual(status_response_body["state"], State.DONE.value)
+        self.assertTrue(
+            "socks_samplesheet_samplesheet.csv"
+            in " ".join(status_response_body["command"])
+        )
+
     def test_stop_job(self):
         # First start the job
-        response = self.fetch('/api/1.0/jobs/start/foo_runfolder', method='POST', body=json.dumps({}))
+        response = self.fetch(
+            '/api/1.0/jobs/start/seqreports/foo_runfolder',
+            method='POST', body=json.dumps({}))
         self.assertEqual(response.code, 202)
         status_link = json.loads(response.body).get('link', None)
         self.assertTrue(status_link)

--- a/tests/test_nextflow.py
+++ b/tests/test_nextflow.py
@@ -1,16 +1,18 @@
-
-import pytest
 import datetime
 import tempfile
 import pathlib
-import yaml
 import shutil
+import yaml
 
-from sequencing_report_service.nextflow import NextflowCommandGenerator, NextflowConfigError
+import pytest
+import jsonschema
+
+from sequencing_report_service.nextflow import *
 
 
-def test_command():
-    config = {
+@pytest.fixture()
+def config():
+    return {
         'main_workflow_path': 'Molmed/summary-report-development',
         'nextflow_parameters': {
             'config': 'config/nextflow',
@@ -29,39 +31,116 @@ def test_command():
         }
     }
 
+
+@pytest.fixture()
+def config_dir(config):
     with tempfile.TemporaryDirectory() as pipeline_config_dir:
         with open(
-                pathlib.Path(pipeline_config_dir) / "pipeline.yml",
+                pathlib.Path(pipeline_config_dir) / "foo_pipeline.yml",
                 'w') as config_file:
             config_file.write(yaml.dump(config))
         shutil.copyfile(
             "config/pipeline_config/schema.json",
             pathlib.Path(pipeline_config_dir) / "schema.json"
         )
+        yield pipeline_config_dir
 
-        cmd_generator = NextflowCommandGenerator(pipeline_config_dir)
-        result = cmd_generator.command("pipeline", '/path/to/runfolder')
 
-        assert result['command'] == [
-            'nextflow',
-            'run', 'Molmed/summary-report-development',
-            '-config', 'config/nextflow',
-            '-profile', 'singularity,snpseq',
-            '--hello', '/path/to/runfolder',
-            '--name', 'runfolder',
-            '--year', str(datetime.datetime.now().year),
-        ]
+@pytest.fixture()
+def runfolder():
+    with tempfile.TemporaryDirectory() as runfolder:
+        yield pathlib.Path(runfolder)
 
-        assert result['environment'] == {
+
+def test_nextflow_command(config_dir, runfolder):
+    result = nextflow_command(
+        "foo_pipeline",
+        str(runfolder),
+        config_dir,
+        "samplesheet,content",
+        ["--params", "foo"],
+    )
+
+    assert result['command'] == [
+        'nextflow',
+        'run', 'Molmed/summary-report-development',
+        '-config', 'config/nextflow',
+        '-profile', 'singularity,snpseq',
+        '--hello', str(runfolder),
+        '--name', runfolder.name,
+        '--year', str(datetime.datetime.now().year),
+        "--params", "foo",
+    ]
+
+    assert result['environment'] == {
+        'NXF_TEMP': '/tmp_foo',
+        'TEST_RUNFOLDER': runfolder.name,
+        'TEST_PATH': str(runfolder),
+        'TEST_YEAR': str(datetime.datetime.now().year),
+    }
+
+    with open(runfolder / "foo_pipeline_samplesheet.csv") as f:
+        assert f.read() == "samplesheet,content"
+
+
+def test_get_config(config_dir, config):
+    test_config = get_config(config_dir, "foo_pipeline")
+    assert test_config == config
+
+
+def test_config_validation(config_dir):
+    with open(pathlib.Path(config_dir) / "erronous_pipeline.yml", 'w') as f:
+        f.write(yaml.dump({'a': 'b'}))
+    with pytest.raises(jsonschema.ValidationError):
+        get_config(config_dir, "erronous_pipeline")
+
+
+def test_config_not_found(config_dir):
+    with pytest.raises(FileNotFoundError):
+        get_config(config_dir, "erronous_pipeline")
+
+
+def test_build_defaults(runfolder):
+    defaults = build_defaults(
+        "foo_pipeline",
+        str(runfolder),
+        "runfolder_data,{runfolder_name}"
+    )
+    assert defaults == {
+        "current_year": datetime.datetime.now().year,
+        "runfolder_path": str(runfolder),
+        "runfolder_name": runfolder.name,
+        "input_samplesheet_path": f"{runfolder}/foo_pipeline_samplesheet.csv",
+    }
+    with open(defaults["input_samplesheet_path"], 'r') as f:
+        assert f.read() == f"runfolder_data,{runfolder.name}"
+
+def test_interpolate_variables(config):
+    defaults = {
+        "current_year": 2024,
+        "runfolder_path": "/path/to/runfolder",
+        "runfolder_name": "runfolder",
+    }
+
+    exp_config = {
+        'main_workflow_path': 'Molmed/summary-report-development',
+        'nextflow_parameters': {
+            'config': 'config/nextflow',
+            'profile': 'singularity,snpseq',
+        },
+        'environment': {
             'NXF_TEMP': '/tmp_foo',
             'TEST_RUNFOLDER': 'runfolder',
             'TEST_PATH': '/path/to/runfolder',
-            'TEST_YEAR': str(datetime.datetime.now().year),
+            'TEST_YEAR': '2024',
+        },
+        'pipeline_parameters': {
+            'hello': '/path/to/runfolder',
+            'year': '2024',
+            'name': 'runfolder',
         }
+    }
 
+    test_config = interpolate_variables(config, defaults)
 
-def test_raises_config_file_not_found():
-    with tempfile.TemporaryDirectory() as pipeline_config_dir:
-        cmd_generator = NextflowCommandGenerator(pipeline_config_dir)
-        with pytest.raises(FileNotFoundError):
-            cmd_generator.command("pipeline", "/path/to/runfolder")
+    assert test_config == exp_config

--- a/tests/test_nextflow.py
+++ b/tests/test_nextflow.py
@@ -1,58 +1,73 @@
 
 import pytest
 import datetime
+import tempfile
+import pathlib
+import yaml
+import shutil
 
 from sequencing_report_service.nextflow import NextflowCommandGenerator, NextflowConfigError
 
 
 def test_command():
-    config = {'main_workflow_path': 'Molmed/summary-report-development',
-              'nf_config': 'config/nextflow',
-              'nf_profile': 'singularity,snpseq',
-              'environment':
-              {
-                  'NXF_TEMP': '/tmp_foo',
-                  'TEST_RUNFOLDER': '${DEFAULT:runfolder_name}',
-                  'TEST_PATH': '${DEFAULT:runfolder_path}',
-                  'TEST_YEAR': '${DEFAULT:current_year}',
-              },
-              'parameters':
-                  {'hello': '${DEFAULT:runfolder_path}',
-                   'year': '${DEFAULT:current_year}',
-                   'name': '${DEFAULT:runfolder_name}'}}
-
-    cmd_generator = NextflowCommandGenerator(config)
-    result = cmd_generator.command('/path/to/runfolder')
-    assert result['command'] == [
-        'nextflow',
-        '-config', 'config/nextflow',
-        'run', 'Molmed/summary-report-development',
-        '-profile', 'singularity,snpseq',
-        '--hello', '/path/to/runfolder',
-        '--year', str(datetime.datetime.now().year),
-        '--name', 'runfolder',
-    ]
-
-    assert result['environment'] == {
-        'NXF_TEMP': '/tmp_foo',
-        'TEST_RUNFOLDER': 'runfolder',
-        'TEST_PATH': '/path/to/runfolder',
-        'TEST_YEAR': str(datetime.datetime.now().year),
+    config = {
+        'main_workflow_path': 'Molmed/summary-report-development',
+        'nf_config': 'config/nextflow',
+        'nf_profile': 'singularity,snpseq',
+        'environment': {
+            'NXF_TEMP': '/tmp_foo',
+            'TEST_RUNFOLDER': '{runfolder_name}',
+            'TEST_PATH': '{runfolder_path}',
+            'TEST_YEAR': '{current_year}',
+        },
+        'parameters': {
+            'hello': '{runfolder_path}',
+            'year': '{current_year}',
+            'name': '{runfolder_name}',
+        }
     }
 
+    with tempfile.TemporaryDirectory() as pipeline_config_dir:
+        with open(
+                pathlib.Path(pipeline_config_dir) / "seqreports.yml",
+                'w') as config_file:
+            config_file.write(yaml.dump(config))
+        with open(
+                pathlib.Path(pipeline_config_dir) / "pipeline.yml",
+                'w') as config_file:
+            config_file.write(yaml.dump(config))
+        shutil.copyfile(
+            "config/pipeline_config/schema.json",
+            pathlib.Path(pipeline_config_dir) / "schema.json"
+        )
 
-def test_raises_on_no_parameters_section():
+        cmd_generator = NextflowCommandGenerator(pipeline_config_dir)
+        results = [
+            cmd_generator.command('/path/to/runfolder'),
+            cmd_generator.command('/path/to/runfolder', "pipeline"),
+        ]
 
-    config = {'main_workflow_path': 'Molmed/summary-report-development',
-              'nf_config': 'config/nextflow'}
-    with pytest.raises(NextflowConfigError):
-        NextflowCommandGenerator(config)
+        for result in results:
+            assert result['command'] == [
+                'nextflow',
+                '-config', 'config/nextflow',
+                'run', 'Molmed/summary-report-development',
+                '-profile', 'singularity,snpseq',
+                '--hello', '/path/to/runfolder',
+                '--name', 'runfolder',
+                '--year', str(datetime.datetime.now().year),
+            ]
+
+            assert result['environment'] == {
+                'NXF_TEMP': '/tmp_foo',
+                'TEST_RUNFOLDER': 'runfolder',
+                'TEST_PATH': '/path/to/runfolder',
+                'TEST_YEAR': str(datetime.datetime.now().year),
+            }
 
 
-def test_raises_on_no_parameters_main_workflow_path():
-
-    config = {'nf_config': 'config/nextflow',
-              'parameters':
-              {'hello': '${DEFAULT:runfolder_path}'}}
-    with pytest.raises(NextflowConfigError):
-        NextflowCommandGenerator(config)
+def test_raises_config_file_not_found():
+    with tempfile.TemporaryDirectory() as pipeline_config_dir:
+        cmd_generator = NextflowCommandGenerator(pipeline_config_dir)
+        with pytest.raises(FileNotFoundError):
+            cmd_generator.command('/path/to/runfolder')

--- a/tests/test_nextflow.py
+++ b/tests/test_nextflow.py
@@ -31,10 +31,6 @@ def test_command():
 
     with tempfile.TemporaryDirectory() as pipeline_config_dir:
         with open(
-                pathlib.Path(pipeline_config_dir) / "seqreports.yml",
-                'w') as config_file:
-            config_file.write(yaml.dump(config))
-        with open(
                 pathlib.Path(pipeline_config_dir) / "pipeline.yml",
                 'w') as config_file:
             config_file.write(yaml.dump(config))
@@ -44,32 +40,28 @@ def test_command():
         )
 
         cmd_generator = NextflowCommandGenerator(pipeline_config_dir)
-        results = [
-            cmd_generator.command('/path/to/runfolder'),
-            cmd_generator.command('/path/to/runfolder', "pipeline"),
+        result = cmd_generator.command("pipeline", '/path/to/runfolder')
+
+        assert result['command'] == [
+            'nextflow',
+            'run', 'Molmed/summary-report-development',
+            '-config', 'config/nextflow',
+            '-profile', 'singularity,snpseq',
+            '--hello', '/path/to/runfolder',
+            '--name', 'runfolder',
+            '--year', str(datetime.datetime.now().year),
         ]
 
-        for result in results:
-            assert result['command'] == [
-                'nextflow',
-                'run', 'Molmed/summary-report-development',
-                '-config', 'config/nextflow',
-                '-profile', 'singularity,snpseq',
-                '--hello', '/path/to/runfolder',
-                '--name', 'runfolder',
-                '--year', str(datetime.datetime.now().year),
-            ]
-
-            assert result['environment'] == {
-                'NXF_TEMP': '/tmp_foo',
-                'TEST_RUNFOLDER': 'runfolder',
-                'TEST_PATH': '/path/to/runfolder',
-                'TEST_YEAR': str(datetime.datetime.now().year),
-            }
+        assert result['environment'] == {
+            'NXF_TEMP': '/tmp_foo',
+            'TEST_RUNFOLDER': 'runfolder',
+            'TEST_PATH': '/path/to/runfolder',
+            'TEST_YEAR': str(datetime.datetime.now().year),
+        }
 
 
 def test_raises_config_file_not_found():
     with tempfile.TemporaryDirectory() as pipeline_config_dir:
         cmd_generator = NextflowCommandGenerator(pipeline_config_dir)
         with pytest.raises(FileNotFoundError):
-            cmd_generator.command('/path/to/runfolder')
+            cmd_generator.command("pipeline", "/path/to/runfolder")

--- a/tests/test_nextflow.py
+++ b/tests/test_nextflow.py
@@ -12,15 +12,17 @@ from sequencing_report_service.nextflow import NextflowCommandGenerator, Nextflo
 def test_command():
     config = {
         'main_workflow_path': 'Molmed/summary-report-development',
-        'nf_config': 'config/nextflow',
-        'nf_profile': 'singularity,snpseq',
+        'nextflow_parameters': {
+            'config': 'config/nextflow',
+            'profile': 'singularity,snpseq',
+        },
         'environment': {
             'NXF_TEMP': '/tmp_foo',
             'TEST_RUNFOLDER': '{runfolder_name}',
             'TEST_PATH': '{runfolder_path}',
             'TEST_YEAR': '{current_year}',
         },
-        'parameters': {
+        'pipeline_parameters': {
             'hello': '{runfolder_path}',
             'year': '{current_year}',
             'name': '{runfolder_name}',
@@ -50,8 +52,8 @@ def test_command():
         for result in results:
             assert result['command'] == [
                 'nextflow',
-                '-config', 'config/nextflow',
                 'run', 'Molmed/summary-report-development',
+                '-config', 'config/nextflow',
                 '-profile', 'singularity,snpseq',
                 '--hello', '/path/to/runfolder',
                 '--name', 'runfolder',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,18 +2,7 @@ import contextlib
 import mock
 
 from sequencing_report_service.repositiories.job_repo import JobRepository
-from sequencing_report_service.nextflow import NextflowCommandGenerator
 from sequencing_report_service.models.db_models import Job, State
-
-
-def create_mock_nextflow_job_factory(error=False):
-    m = mock.create_autospec(NextflowCommandGenerator)
-    if error:
-        cmd = ['cat --incorrect']
-    else:
-        cmd = ['sleep', '2', ';', 'echo', 'hello']
-    m.command.return_value = {'command': cmd, 'environment': {'foo': 'bar'}}
-    return m
 
 
 class MockJobRepository():

--- a/tests/unit/handlers/test_job_handler.py
+++ b/tests/unit/handlers/test_job_handler.py
@@ -48,7 +48,7 @@ class TestJobHandler(AsyncHTTPTestCase):
         self.assertEqual(resp_dict['state'], 'pending')
 
     def test_start_job(self):
-        response = self.fetch('/api/1.0/jobs/start/foo', method='POST', body=json.dumps({}))
+        response = self.fetch('/api/1.0/jobs/start/foo/bar', method='POST', body=json.dumps({}))
         self.assertEqual(response.code, 202)
         self.assertDictEqual(json.loads(response.body),
                              {'link':

--- a/tests/unit/services/test_local_runner_service.py
+++ b/tests/unit/services/test_local_runner_service.py
@@ -1,5 +1,4 @@
 
-import pytest
 
 import asyncio
 import mock
@@ -7,19 +6,15 @@ import tempfile
 import os
 import time
 
+import pytest
+
 from sequencing_report_service.services.local_runner_service import LocalRunnerService
 from sequencing_report_service.models.db_models import Job, State
 
 from tests.test_utils import MockJobRepository
-from tests.test_utils import create_mock_nextflow_job_factory
 
 
 class TestLocalRunnerService(object):
-
-    @pytest.fixture
-    def nextflow_cmd_generator(self):
-        return create_mock_nextflow_job_factory()
-
     @pytest.fixture
     def job_repo_factory(self):
         data = []
@@ -33,9 +28,16 @@ class TestLocalRunnerService(object):
         return tempfile.mkdtemp()
 
     @pytest.mark.asyncio
+    @mock.patch(
+        "sequencing_report_service.services.local_runner_service.nextflow_command",
+        return_value={
+            "command": ["nextflow", "run", "socks"],
+            "environment": {},
+        },
+    )
     async def test_start(
             self,
-            nextflow_cmd_generator,
+            mock_nextflow_command,
             job_repo_factory,
             nextflow_log_dirs,
             ):
@@ -43,10 +45,9 @@ class TestLocalRunnerService(object):
         runfolder = 'foo_runfolder'
         local_runner_service = LocalRunnerService(
             job_repo_factory,
-            nextflow_cmd_generator,
+            "/path/to/config/dir",
             nextflow_log_dirs,
         )
-        command, environment = nextflow_cmd_generator.command(pipeline, runfolder).values()
 
         with mock.patch("subprocess.Popen"):
             job_id = local_runner_service.start(pipeline, runfolder)
@@ -54,9 +55,16 @@ class TestLocalRunnerService(object):
         assert isinstance(local_runner_service.get_job(job_id), Job)
 
     @pytest.mark.asyncio
+    @mock.patch(
+        "sequencing_report_service.services.local_runner_service.nextflow_command",
+        return_value={
+            "command": ["nextflow", "run", "socks"],
+            "environment": {},
+        },
+    )
     async def test_stop(
             self,
-            nextflow_cmd_generator,
+            mock_nextflow_command,
             job_repo_factory,
             nextflow_log_dirs
             ):
@@ -64,7 +72,7 @@ class TestLocalRunnerService(object):
         runfolder = 'foo_runfolder'
         local_runner_service = LocalRunnerService(
             job_repo_factory,
-            nextflow_cmd_generator,
+            "/path/to/config/dir",
             nextflow_log_dirs,
         )
         with mock.patch("subprocess.Popen"):
@@ -78,13 +86,12 @@ class TestLocalRunnerService(object):
     @pytest.mark.asyncio
     async def test_start_process(
             self,
-            nextflow_cmd_generator,
             job_repo_factory,
             nextflow_log_dirs
             ):
         local_runner_service = LocalRunnerService(
             job_repo_factory,
-            nextflow_cmd_generator,
+            "/path/to/config/dir",
             nextflow_log_dirs,
         )
 
@@ -106,13 +113,12 @@ class TestLocalRunnerService(object):
     @pytest.mark.asyncio
     async def test_start_process_fail(
             self,
-            nextflow_cmd_generator,
             job_repo_factory,
             nextflow_log_dirs
             ):
         local_runner_service = LocalRunnerService(
             job_repo_factory,
-            nextflow_cmd_generator,
+            "/path/to/config/dir",
             nextflow_log_dirs,
         )
 

--- a/tests/unit/services/test_local_runner_service.py
+++ b/tests/unit/services/test_local_runner_service.py
@@ -39,16 +39,17 @@ class TestLocalRunnerService(object):
             job_repo_factory,
             nextflow_log_dirs,
             ):
+        pipeline = "seqreports"
         runfolder = 'foo_runfolder'
         local_runner_service = LocalRunnerService(
             job_repo_factory,
             nextflow_cmd_generator,
             nextflow_log_dirs,
         )
-        command, environment = nextflow_cmd_generator.command(runfolder).values()
+        command, environment = nextflow_cmd_generator.command(pipeline, runfolder).values()
 
         with mock.patch("subprocess.Popen"):
-            job_id = local_runner_service.start(runfolder)
+            job_id = local_runner_service.start(pipeline, runfolder)
 
         assert isinstance(local_runner_service.get_job(job_id), Job)
 
@@ -59,6 +60,7 @@ class TestLocalRunnerService(object):
             job_repo_factory,
             nextflow_log_dirs
             ):
+        pipeline = "seqreports"
         runfolder = 'foo_runfolder'
         local_runner_service = LocalRunnerService(
             job_repo_factory,
@@ -66,7 +68,7 @@ class TestLocalRunnerService(object):
             nextflow_log_dirs,
         )
         with mock.patch("subprocess.Popen"):
-            job_id = local_runner_service.start(runfolder)
+            job_id = local_runner_service.start(pipeline, runfolder)
             time.sleep(1)
             stopped_id = local_runner_service.stop(job_id)
 


### PR DESCRIPTION
**What problems does this PR solve?**
This PR is the first step towards enabling the service to run multiple pipelines. It updates the nextflow command generator so that it can run arbitrary pipelines from a pipeline config file, which format is specified in the following schema: https://github.com/arteria-project/sequencing-report-service/blob/53b153f195b784aa2a2cc3be0a1dd147c7ba54ac/config/pipeline_config/schema.json.

Nf-core pipelines use a specific input samplesheet to determine what to process (see [nf-core/demultiplex](https://nf-co.re/demultiplex/1.4.0/docs/usage#samplesheet-input) for instance). The service handles this by writing down such samplesheet in the runfolder to be processed. The content of this samplesheet can either be provided in the pipeline's configuration file or as a parameter to the handler.

**How has the changes been tested?**
Tests have been updated, full validation should check both old and new pipelines.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be initiated.

  - [ ] This PR contains code that could remove data