### PR TITLE
Update seqreports: Increase time for FastQC and FastQ Screen slurm jobs

### DIFF
--- a/sequencing_report_service/__init__.py
+++ b/sequencing_report_service/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Johan Dahlberg"""
 __email__ = 'johan.dahlberg@medsci.uu.se'
-__version__ = '1.5.0-rc2'
+__version__ = '1.5.0-rc3'


### PR DESCRIPTION
Changes: 
- seqreports version updated, it contains this changes:
  - Slurm time limits updated: https://github.com/Molmed/seqreports/pull/59
  - Black version updated: https://github.com/Molmed/seqreports/pull/58
- Version bumped to v1.5.0-rc3

I though this small change could be part of the release candidate since https://github.com/NationalGenomicsInfrastructure/miarka-provision/pull/230 has not been merged yet. Let me know what you think.