### PR TITLE
Update seqreports version - nextflow 25.10.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
         with:
-          version: "24.04.2"
+          version: "25.10.2"
       - name: Test nextflow
         run: nextflow run -revision main socks --style ascii
       - name: Install apptainer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sequencing-report-service"
-version = "1.6.0-rc2"
+version = "1.6.0-rc3"
 description = "Service producing and displaying sequencing reports."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Description:
This PR updates the seqreports pipeline to the latest version, which support nextflow 25.10.2.

Risk analysis:
There is a risk that the other pipelines can't handle nextflow 25.10.2. That should hopefully be caught in unit tests and manual verification.

Validation procedure:
Run all pipelines in miarka staging env. 