### PR TITLE
Verify lock file in GHA

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+**When preparing a release, do this before merging**
+
+- [ ] Update version in pyproject.toml
+- [ ] Run `uv lock` to update the lock file
+
 **Description**
 Provide a short description or reference to the relevant issue, explaining what problems this PR solves.
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,38 +13,50 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
           activate-environment: "true"
           enable-cache: true
+
       - name: Setup virtual environment
         run: |
           uv venv --clear
           source .venv/bin/activate
+      
+      - name: Verify lock file
+        run: uv lock --check
+  
       - name: Install dependencies
         run: |
           uv pip install wheel
-          uv sync --all-groups
+          uv sync --all-groups --locked
           npm install -g pajv
+
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
         with:
           version: "25.10.2"
+
       - name: Test nextflow
         run: nextflow run -revision main socks --style ascii
+
       - name: Install apptainer
         run: |
           sudo add-apt-repository -y ppa:apptainer/ppa
           sudo apt update
           sudo apt install -y apptainer
+
       - name: Launch tests
         run: |
           uv run pytest ./tests
+
       - name: Validate pipeline config files
         run: >
           pajv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nextflow-runner-service"
-version = "2.0.0-rc1"
+version = "2.0.0-rc2"
 description = "Service starting configured nextflow pipelines."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -595,7 +595,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-runner-service"
-version = "2.0.0rc1"
+version = "2.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -595,7 +595,7 @@ wheels = [
 
 [[package]]
 name = "nextflow-runner-service"
-version = "1.6.0"
+version = "2.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
**When preparing a release, do this before merging**

- [x] Update version in pyproject.toml
- [x] Run `uv lock` to update the lock file

**Description**
When trying to deploy 2.0.0-rc1 in the dev env of miarka-provision, uv threw an error due to an outdated lock file. At first I did not understand this, but after looking into this I realized that a service version change (i.e. updating the version in pyproject.toml) updates the lock file, which means that we have to make sure that the lock file is updated after updating the service version tag. 

I added a check list for the in the PR template as well as making sure we test the lock file in the GHA workflow. I also added newlines between the steps in the GHA workflow to make it easier to read. 

**Risk analysis**
No risks identified. 

**Validation procedure**
Will be verified in the next bimonthly deployment of miarka-provision.
